### PR TITLE
Limits of things

### DIFF
--- a/app.py
+++ b/app.py
@@ -182,8 +182,9 @@ def toggle(todo_id):
         flash('Task completed and auto-deleted.', 'info')
     else:
         db.session.commit()
-        
-    return redirect(url_for('todo', category=request.args.get('category', '')))
+    return redirect(url_for('todo', 
+                            category=request.args.get('category', ''), 
+                            page=request.args.get('page', 1)))
 
 @app.post('/todo/<int:todo_id>/delete')
 @login_required
@@ -196,7 +197,9 @@ def delete(todo_id):
         if not cat.todos:
             db.session.delete(cat)
     db.session.commit()
-    return redirect(url_for('todo', category=request.args.get('category', '')))
+    return redirect(url_for('todo', 
+                            category=request.args.get('category', ''), 
+                            page=request.args.get('page', 1)))
 
 @app.post('/update_preferences')
 @login_required
@@ -384,19 +387,17 @@ def todo():
             db.session.add(new_todo)
             db.session.commit()
             flash('Task added!', 'success')
-            return redirect(url_for('todo', category=request.args.get('category', '')))
+            return redirect(url_for('todo', category=request.args.get('category', ''), page=request.args.get('page', 1)))
 
-    # --- GET LOGIC ---
+    page = request.args.get('page', 1, type=int)
     selected_category_input = request.args.get('category', '')
     q = Todo.query.options(joinedload(Todo.categories)).filter_by(user_id=current_user.id)
     
-    # 1. APPLY INTERSECTION (AND) FILTER
     if selected_category_input:
         cat_filter_list = [c.strip().upper() for c in selected_category_input.split(',') if c.strip()]
         for cat_name in cat_filter_list:
             q = q.filter(Todo.categories.any(Category.name == cat_name))
 
-    # 2. APPLY SORTING PREFERENCE
     sort_pref = session.get('sort_by', 'newest')
     if sort_pref == 'alpha':
         q = q.order_by(Todo.completed.asc(), Todo.task.asc())
@@ -405,12 +406,12 @@ def todo():
     else:  # Default to 'newest'
         q = q.order_by(Todo.completed.asc(), Todo.id.desc())
 
-    tasks = q.distinct().all()
+    pagination = q.distinct().paginate(page=page, per_page=10, error_out=False)
     user_cat_ids = db.session.query(Category.id).join(Todo.categories).filter(Todo.user_id == current_user.id).distinct()
     categories = Category.query.filter(Category.id.in_(user_cat_ids)).order_by(Category.name).all()
 
     return render_template('todo.html', 
-                         tasks=tasks, 
+                         pagination=pagination,
                          categories=categories, 
                          selected_category=selected_category_input, 
                          toggle_cat=toggle_category_string)
@@ -423,7 +424,7 @@ def version():
     try:
         response = requests.get(url, headers={"User-Agent": "ToPlanBlock-App"}, timeout=10)
         if response.status_code == 200:
-            releases = response.json()
+            releases = response.json()[:5]
     except Exception as e:
         app.logger.error(f"GitHub API Error: {e}")
 

--- a/templates/todo.html
+++ b/templates/todo.html
@@ -8,7 +8,7 @@
     <div class="card shadow-sm border-0 mb-4">
       <div class="card-body">
         <h4 class="card-title mb-4">Add Task</h4>
-        <form method="POST" id="todo-form">
+        <form method="POST" id="todo-form" action="{{ url_for('todo', category=selected_category, page=pagination.page) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
           <!-- Task Name -->
@@ -66,10 +66,20 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
       <h4>{% if selected_category %}Filtered: <span class="text-primary">{{ selected_category }}</span>{% else %}Your
         Tasks{% endif %}</h4>
+      {% if pagination.total > 0 %}
+      <small class="text-muted">
+        Showing
+        <strong>{{ (pagination.page - 1) * pagination.per_page + 1 }}</strong>
+        to
+        <strong>{{ (pagination.page - 1) * pagination.per_page + pagination.items|length }}</strong>
+        of
+        <strong>{{ pagination.total }}</strong>
+      </small>
+      {% endif %}
     </div>
 
-    <ul class="list-group shadow-sm">
-      {% for t in tasks %}
+    <ul class="list-group shadow-sm mb-4">
+      {% for t in pagination.items %}
       <li class="list-group-item d-flex justify-content-between align-items-center py-3">
         <div class="d-flex flex-column">
           <div class="d-flex gap-1 mb-1">
@@ -81,8 +91,10 @@
             {{ t.task }}
           </span>
         </div>
+
         <div class="d-flex gap-2">
-          <form method="POST" action="{{ url_for('toggle', todo_id=t.id, category=selected_category) }}">
+          <form method="POST"
+            action="{{ url_for('toggle', todo_id=t.id, category=selected_category, page=pagination.page) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <button class="btn btn-sm {{ 'btn-success' if t.completed else 'btn-outline-primary' }}">
               {% if t.completed %}Done{% else %}Mark Done{% endif %}
@@ -91,13 +103,14 @@
 
           {% if session.get('confirm_delete', True) %}
           <button class="btn btn-outline-danger btn-sm"
-            data-url="{{ url_for('delete', todo_id=t.id, category=selected_category) }}" data-bs-toggle="modal"
-            data-bs-target="#deleteModal" onclick="prepareDelete(this.dataset.url)">
+            data-url="{{ url_for('delete', todo_id=t.id, category=selected_category, page=pagination.page) }}"
+            data-bs-toggle="modal" data-bs-target="#deleteModal" onclick="prepareDelete(this.dataset.url)">
             Delete
           </button>
 
           {% else %}
-          <form method="POST" action="{{ url_for('delete', todo_id=t.id, category=selected_category) }}">
+          <form method="POST"
+            action="{{ url_for('delete', todo_id=t.id, category=selected_category, page=pagination.page) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <button class="btn btn-outline-danger btn-sm">Delete</button>
           </form>
@@ -110,6 +123,33 @@
       </li>
       {% endfor %}
     </ul>
+
+    {% if pagination.pages > 1 %}
+    <nav aria-label="Task pagination">
+      <ul class="pagination justify-content-center">
+        <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+          <a class="page-link"
+            href="{{ url_for('todo', category=selected_category, page=pagination.prev_num) if pagination.has_prev else '#' }}">Previous</a>
+        </li>
+
+        {% for page_num in pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+        {% if page_num %}
+        <li class="page-item {% if page_num == pagination.page %}active{% endif %}">
+          <a class="page-link" href="{{ url_for('todo', category=selected_category, page=page_num) }}">{{ page_num
+            }}</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">...</span></li>
+        {% endif %}
+        {% endfor %}
+
+        <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+          <a class="page-link"
+            href="{{ url_for('todo', category=selected_category, page=pagination.next_num) if pagination.has_next else '#' }}">Next</a>
+        </li>
+      </ul>
+    </nav>
+    {% endif %}
   </div>
 </div>
 


### PR DESCRIPTION
# Dev Progression: Added pagination

## Summary
This update implements server-side pagination for the task list to improve performance and UI clarity. It also restricts the GitHub release history to the 5 most recent entries and ensures that user actions (creating, toggling, or deleting tasks) preserve the current pagination state.

## Key Changes
- **Task Pagination**: Integrated SQLAlchemy's `.paginate()` in the `/todo` route, setting a limit of 10 tasks per page.
- **State Persistence**: Updated the `todo`, `toggle`, and `delete` routes to capture and pass the `page` query parameter, preventing the app from resetting to page 1 after every action.
- **UI Navigation**: Added dynamic pagination controls (Previous, Next, and page numbers) to `todo.html`, which maintain active category filters.
- **Release Optimization**: Modified the `/version` route to slice the GitHub API response, displaying only the latest 5 releases.
- **Form Synchronization**: Updated the task creation form in `todo.html` to include the current `page` and `category` in its action URL, ensuring the user remains on their current "set" after adding a task.